### PR TITLE
use strict, fix global leak, and allow passing src string

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -77,12 +77,8 @@ URL: https://github.com/Huddle/Resemble.js
 		}
 
 		function loadImageData( fileData, callback ){
-			var hiddenImage = new Image();
-			var fileReader = new FileReader();
-			
-			fileReader.onload = function (event) {
-				hiddenImage.src = event.target.result;
-			};
+			var fileReader,
+				hiddenImage = new Image();
 
 			hiddenImage.onload = function() {
 
@@ -100,8 +96,16 @@ URL: https://github.com/Huddle/Resemble.js
 
 				callback(imageData, width, height);
 			};
-				
-			fileReader.readAsDataURL(fileData);
+
+			if (typeof fileData === 'string') {
+				hiddenImage.src = fileData;
+			} else {
+				fileReader = new FileReader();
+				fileReader.onload = function (event) {
+					hiddenImage.src = event.target.result;
+				};
+				fileReader.readAsDataURL(fileData);
+			}
 		}
 
 		function isColorSimilar(a, b, color){


### PR DESCRIPTION
This library is useful for more than just for uploading images. It should be more versatile by accepting a string which may be a src URL already retrieved by another canvas.
