### PR TITLE
Add support for cross origin

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -108,6 +108,7 @@ URL: https://github.com/Huddle/Resemble.js
 		function loadImageData( fileData, callback ){
 			var fileReader;
 			var hiddenImage = new Image();
+                        hiddenImage.setAttribute("crossOrigin", "crossOrigin");
 
 			hiddenImage.onload = function() {
 


### PR DESCRIPTION
Both side of a cross origin request should be aware of it. It is done on
the client side through a crossOrigin attribute on the image.
http://stackoverflow.com/questions/12947361/cors-settings-for-images-in-canvas
https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
