### PR TITLE
Add largeImageThreshold option to control when to skip pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,15 @@ resemble.outputSettings({
     blue: 255
   },
   errorType: 'movement',
-  transparency: 0.3
+  transparency: 0.3,
+  largeImageThreshold: 1200
 });
 // resembleControl.repaint();
 ```
+
+By default, the comparison algorithm skips pixels when the image width or height is larger than 1200 pixels. This is there to mitigate performance issues.
+
+You can switch this modify this behaviour by setting the `largeImageThreshold` option to a different value. Set it to **0** to switch it off completely.
 
 --------------------------------------
 

--- a/resemble.js
+++ b/resemble.js
@@ -33,8 +33,10 @@ URL: https://github.com/Huddle/Resemble.js
 			}
 		}
 	};
-	
+
 	var errorPixelTransformer = errorPixelTransform.flat;
+
+	var largeImageThreshold = 1200;
 
 	_this['resemble'] = function( fileData ){
 
@@ -347,7 +349,7 @@ URL: https://github.com/Huddle/Resemble.js
 
 			var skip;
 
-			if( (width > 1200 || height > 1200) && ignoreAntialiasing){
+			if(!!largeImageThreshold && ignoreAntialiasing && (width > largeImageThreshold || height > largeImageThreshold)){
 				skip = 6;
 			}
 
@@ -592,8 +594,10 @@ URL: https://github.com/Huddle/Resemble.js
 		if(options.errorType && errorPixelTransform[options.errorType] ){
 			errorPixelTransformer = errorPixelTransform[options.errorType];
 		}
-		
+
 		pixelTransparency = options.transparency || pixelTransparency;
+
+		largeImageThreshold = options.largeImageThreshold || largeImageThreshold;
 
 		return this;
 	};


### PR DESCRIPTION
This adds an option to control pixel skipping for large images.

The arbitrary 1200 pixel limit is now configurable and setting it to zero switches off skipping completely.

Related to https://github.com/Huddle/Resemble.js/pull/21
