### PR TITLE
Fix how largeImageThreshold option is set

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -597,7 +597,9 @@ URL: https://github.com/Huddle/Resemble.js
 
 		pixelTransparency = options.transparency || pixelTransparency;
 
-		largeImageThreshold = options.largeImageThreshold || largeImageThreshold;
+		if (options.largeImageThreshold !== undefined) {
+			largeImageThreshold = options.largeImageThreshold;
+		}
 
 		return this;
 	};


### PR DESCRIPTION
The change in #22 didn't allow setting `largeImageThreshold` to `0`. This fixes it.
