### PR TITLE
Updated crossorigin settings

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -37,6 +37,9 @@ URL: https://github.com/Huddle/Resemble.js
 	var errorPixelTransformer = errorPixelTransform.flat;
 
 	var largeImageThreshold = 1200;
+	
+	var httpRegex = /^https?:\/\//;
+	var documentDomainRegex = new RegExp('^https?://' + document.domain);
 
 	_this['resemble'] = function( fileData ){
 
@@ -110,7 +113,10 @@ URL: https://github.com/Huddle/Resemble.js
 		function loadImageData( fileData, callback ){
 			var fileReader;
 			var hiddenImage = new Image();
-						hiddenImage.setAttribute("crossOrigin", "crossOrigin");
+			
+			if (httpRegex.test(fileData) && !documentDomainRegex.test(fileData)) {
+				hiddenImage.setAttribute('crossorigin', 'anonymous');
+			}
 
 			hiddenImage.onload = function() {
 


### PR DESCRIPTION
The crossorigin settings are currently breaking image tests in Firefox and Safari when the images are not cross-domain (e.g. images specified as base64 strings, or using relative pathing).

This change enables CORS on the image if and only if the image is 1) specified using absolute pathing with the HTTP or HTTPS protocol and 2) the image is from a different domain than resemble.js is being run on.
