### PR TITLE
Call hiddenImage.onload if image is cached

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -131,6 +131,9 @@ URL: https://github.com/Huddle/Resemble.js
 
 			if (typeof fileData === 'string') {
 				hiddenImage.src = fileData;
+				if (hiddenImage.complete) {
+					hiddenImage.onload();
+				}
 			} else if (typeof fileData.data !== 'undefined'
 					&& typeof fileData.width === 'number'
 					&& typeof fileData.height === 'number') {


### PR DESCRIPTION
The onload event for hiddenImage is not being called if its src is already in the browser's cache.  Check hiddenImage.complete and if true, invoke onload immediately.
