### PR TITLE
Added two distance-based types of errorPixelTransform

### DIFF
--- a/demoassets/main.js
+++ b/demoassets/main.js
@@ -151,6 +151,20 @@ $(function(){
 			resembleControl.repaint();
 		}
 		else
+		if($this.is('#flatWithDistanceBasedIntensity')){
+			resemble.outputSettings({
+				errorType: 'flatWithDistanceBasedIntensity'
+			});
+			resembleControl.repaint();
+		}
+		else
+		if($this.is('#movementWithDistanceBasedIntensity')){
+			resemble.outputSettings({
+				errorType: 'movementWithDistanceBasedIntensity'
+			});
+			resembleControl.repaint();
+		}
+		else
 		if($this.is('#opaque')){
 			resemble.outputSettings({
 				transparency: 1

--- a/index.html
+++ b/index.html
@@ -102,6 +102,8 @@
 								<div class="btn-group buttons" style="display:none">
 									<button class="btn active" id="flat">Flat</button>
 									<button class="btn" id="movement">Movement</button>
+									<button class="btn" id="flatWithDistanceBasedIntensity">Flat with distance-based intensity</button>
+									<button class="btn" id="movementWithDistanceBasedIntensity">Movement with distance-based intensity</button>
 								</div>
 								
 								<div class="btn-group buttons" style="display:none">

--- a/resemble.js
+++ b/resemble.js
@@ -15,6 +15,10 @@ URL: https://github.com/Huddle/Resemble.js
 		alpha: 255
 	};
 
+  function colorsDistance(c1, c2){
+   return (Math.abs(c1.r - c2.r) + Math.abs(c1.g - c2.g) + Math.abs(c1.b - c2.b))/3;
+  }
+
 	var errorPixelTransform = {
 		flat : function (d1, d2){
 			return {
@@ -29,6 +33,23 @@ URL: https://github.com/Huddle/Resemble.js
 				r: ((d2.r*(errorPixelColor.red/255)) + errorPixelColor.red)/2,
 				g: ((d2.g*(errorPixelColor.green/255)) + errorPixelColor.green)/2,
 				b: ((d2.b*(errorPixelColor.blue/255)) + errorPixelColor.blue)/2,
+				a: d2.a
+			}
+		},
+		flatWithDistanceBasedIntensity: function (d1, d2){
+			return {
+				r: errorPixelColor.red,
+				g: errorPixelColor.green,
+				b: errorPixelColor.blue,
+				a: colorsDistance(d1, d2)
+			}
+		},
+		movementWithDistanceBasedIntensity: function (d1, d2){
+			var ratio = colorsDistance(d1, d2)/255 * 0.8;
+			return {
+				r: ((1-ratio)*(d2.r*(errorPixelColor.red/255)) + ratio*errorPixelColor.red),
+				g: ((1-ratio)*(d2.g*(errorPixelColor.green/255)) + ratio*errorPixelColor.green),
+				b: ((1-ratio)*(d2.b*(errorPixelColor.blue/255)) + ratio*errorPixelColor.blue),
 				a: d2.a
 			}
 		}


### PR DESCRIPTION
This pull request is related to #4 .
It adds two types of errorPixelTransforms, that show distance between color of a pixel on two images.
New options are also added to demo page.

The names (flatWithDistanceBasedIntensity and movementWithDistanceBasedIntensity) are probably not the most catchy names in the world, so I'm open to suggestions on how to change them.
