### PR TITLE
Accelerate Batch Processing with misMatchThreshold Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,13 @@ The resemble.compare API provides a convenience function that is used as follows
 const compare = require("resemblejs").compare;
 
 function getDiff() {
-    const options = {};
+    const options = {
+      // stop comparing once determined to be > 5% non-matching; this will
+      // also enable compare-only mode and no output image will be rendered;
+      // the combination of these results in a significant speed-up in batch processing
+      misMatchThreshold: 5
+    };
+
     // The parameters can be Node Buffers
     // data is the same as usual with an additional getBuffer() function
     compare(image1, image2, options, function(err, data) {


### PR DESCRIPTION
I need to process photos en masse, but it's very slow when comparing full images and rendering new diff images, but I only need to know if a photo doesn't match and need no diff image, so I've added this `misMatchThreshold` option to help speed up processing. If a threshold [percentage] is specified, pixel comparisons will stop for the image once exceeded.

Side note: I've also switched to using `sharp` to scale the images equally before running `resemble` and, in my testing, that shaved on average about 2 seconds off the processing for each comparison (versus using Resemble's built-in scaling).