### PR TITLE
Fix: Invalid image causes UnhandledPromiseRejectionWarning

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -316,6 +316,10 @@ var isNode = new Function("try {return this===global;}catch(e){return false;}");
                     hiddenImage.onload = null; // fixes pollution between calls
                     hiddenImage.onerror = null;
                     onLoadImage(image, callback);
+                })
+                .catch(function(err) {
+                    images.push({ error: err ? err + "" : "Image load error." });
+                    callback();
                 });
             } else {
                 fileReader = new FileReader();


### PR DESCRIPTION
Calling `compareImages` with an invalid or unsupported image results in an `UnhandledPromiseRejectionWarning` which can crash Node.

This fix simply handles the error.

Example code to re-create this error:
```
const compareImages = require('resemblejs/compareImages');
compareImages(
    Buffer.from(''),
    Buffer.from(''),
    {}).then(console.log).catch(console.error);
```

Without my fix this is the result:
```
(node:36851) UnhandledPromiseRejectionWarning: Error: Unsupported image type
    at setSource (/tasks/node_modules/canvas/lib/image.js:97:13)
    at Image.set (/tasks/node_modules/canvas/lib/image.js:63:7)
    at Promise (/tasks/node_modules/canvas/index.js:34:15)
    at new Promise (<anonymous>)
    at loadImage (/tasks/node_modules/canvas/index.js:23:10)
    at loadImageData (/tasks/node_modules/resemblejs/resemble.js:315:17)
    at compare (/tasks/node_modules/resemblejs/resemble.js:817:13)
    at wrapper (/tasks/node_modules/resemblejs/resemble.js:938:25)
    at Object.onComplete (/tasks/node_modules/resemblejs/resemble.js:941:21)
    at Function.resemble.compare (/tasks/node_modules/resemblejs/resemble.js:1031:17)
(node:36851) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
(node:36851) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js
process with a non-zero exit code.
(node:36851) UnhandledPromiseRejectionWarning: Error: Unsupported image type
    at setSource (/tasks/node_modules/canvas/lib/image.js:97:13)
    at Image.set (/tasks/node_modules/canvas/lib/image.js:63:7)
    at Promise (/tasks/node_modules/canvas/index.js:34:15)
    at new Promise (<anonymous>)
    at loadImage (/tasks/node_modules/canvas/index.js:23:10)
    at loadImageData (/tasks/node_modules/resemblejs/resemble.js:315:17)
    at compare (/tasks/node_modules/resemblejs/resemble.js:818:13)
    at wrapper (/tasks/node_modules/resemblejs/resemble.js:938:25)
    at Object.onComplete (/tasks/node_modules/resemblejs/resemble.js:941:21)
    at Function.resemble.compare (/tasks/node_modules/resemblejs/resemble.js:1031:17)
(node:36851) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
```

With my fix this is the result:
```
Error: Unsupported image type
```