### PR TITLE
Change require to window.require

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -24,7 +24,7 @@ var isNode = new Function(
     var loadNodeCanvasImage;
 
     if (isNode()) {
-        Canvas = require("canvas"); // eslint-disable-line global-require
+        Canvas = window.require("canvas"); // eslint-disable-line global-require
         Img = Canvas.Image;
         loadNodeCanvasImage = Canvas.loadImage;
     } else {


### PR DESCRIPTION
This shuts up linters and comilers (e.g. closure) complaining about 'require' being an undeclared variable.

This fixes the integration of resemblejs into the Gerrit image-diff plugin.