### PR TITLE
resemble.outputSettings message

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,4 +264,6 @@ As people have asked in the past, Resemble.js hasn't knowingly implemented any p
 
 ---
 
+>Note: `resemble.outputSettings` mutates global state, and will be removed in a later major version
+
 Created by [James Cryer](http://github.com/jamescryer) and the [Huddle development team](https://github.com/HuddleEng).

--- a/resemble.js
+++ b/resemble.js
@@ -1069,9 +1069,6 @@ var isNode = new Function(
     };
 
     function setGlobalOutputSettings(settings) {
-        var msg =
-            "resemble.outputSettings mutates global state, and will be removed in a later major version";
-        console.warn(msg);
         globalOutputSettings = settings;
         return resemble;
     }


### PR DESCRIPTION
Removed the `resemble.outputSettings` message to show up as a warning and instead added it in the documentation