### PR TITLE
fix: problem installing on node.js > 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
             "git add"
         ]
     },
-    "dependencies": {
+    "optionalDependencies": {
         "canvas": "2.6.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Using yarn to install this package on node.js > 12, such as lts/fermium will fail.  Moving "canvas" dependency to "optionalDependencies" will at least allow yarn to install it without failing. #200 #192