### PR TITLE
Update canvas to 2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         ]
     },
     "optionalDependencies": {
-        "canvas": "2.9.0"
+        "canvas": "2.11.0"
     },
     "devDependencies": {
         "chai": "^4.3.6",


### PR DESCRIPTION
This canvas update includes a nan update to support node 18+.